### PR TITLE
Set default stdout_callback for new projects to yaml

### DIFF
--- a/files/ansible.cfg
+++ b/files/ansible.cfg
@@ -13,6 +13,7 @@ command_warnings = True
 fact_caching = memory
 retry_files_enabled = False
 forks = 25
+stdout_callback = yaml
 
 [diff]
 always = True


### PR DESCRIPTION
Much easier on the eyes than error messages in json.