### PR TITLE
Playbook url at the end of playbook run has changed

### DIFF
--- a/files/longboat.py
+++ b/files/longboat.py
@@ -157,5 +157,5 @@ class CallbackModule(CallbackBase):
         )
 
     def v2_playbook_on_stats(self, stats):
-        self._display.display("https://longboat.io/logbook/session/" + self.longboat.session)
+        self._display.display("https://longboat.io/playbook/" + self.longboat.session)
 


### PR DESCRIPTION
The old URL is still supported, but lets use the shorter and better
looking url for this.