### PR TITLE
Adding boat version and show version info on boat upgrade

### DIFF
--- a/boat
+++ b/boat
@@ -86,10 +86,23 @@ case "${COMMAND}" in
 "auth")
   # shellcheck source=bin/auth
   source "${BOATDIR}/bin/auth" ; exit $? ;;
+"version")
+  cd "${BOATDIR}" || exit 1
+  VERSION=$(git tag -l | tail -1)
+  info "Longboat CLI ${VERSION}"
+  space "https://github.com/longboatio/cli/releases"
+  ;;
 "upgrade")
-  echo "==> Pulling latest version of Longboat CLI..."
-  cd "${BOATDIR}" && git pull -q
-  echo "==> ...done! We highly recommend running: boat doctor"
+  cd "${BOATDIR}" || exit 1
+  CURRENT_VERSION=$(git tag -l | tail -1)
+  git pull -q || exit 1
+  NEW_VERSION=$(git tag -l | tail -1)
+  if [ "${CURRENT_VERSION}" == "${NEW_VERSION}" ] ; then
+    info "Already at latest version ${NEW_VERSION}"
+  else
+    ok "Longboat CLI upgraded from ${CURRENT_VERSION} to ${NEW_VERSION}"
+    space "We highly recommend running: boat doctor"
+  fi
   ;;
 *)
   # shellcheck source=bin/help

--- a/help/boat
+++ b/help/boat
@@ -5,7 +5,8 @@ Usage:
 
 Commands:
   pull        Pull latest updates for local files and projects.
-  upgrade     Pull latest version of CLI tools.
+  version     Show Longboat CLI version.
+  upgrade     Upgrade to latest version of Longboat CLI.
   doctor      Check Longboat installation and project.
 
 User commands:
@@ -15,6 +16,7 @@ User commands:
 Project commands:
   init        Intialize a new project directory.
   project     Manage projects.
+  job         Manage jobs.
   env         Manage environments.
   host        Manage hosts.
   group       Manage host groups.


### PR DESCRIPTION
Adding a command to view the release version of CLI: `boat version`

Updated the `boat upgrade` command to show version info on upgrades.